### PR TITLE
Added markdown-it-anchor

### DIFF
--- a/Markdown2Html/markdown2html.ts
+++ b/Markdown2Html/markdown2html.ts
@@ -25,6 +25,7 @@ import mdit = require('markdown-it');
 import lazyHeaders = require('markdown-it-lazy-headers');
 import dust = require('dustjs-linkedin');
 import util = require('util');
+import mditAnchor = require ('markdown-it-anchor');
 
 function transformTemplate(templatePath: string, templateObject: any) {
 	let deferred = q.defer();
@@ -100,7 +101,12 @@ function run() {
 
 			tl.debug("Reading file " + markdownPath + " succeeded!");
 
-			var md = mdit().use(lazyHeaders);
+			var md = mdit();
+			md.use(lazyHeaders);
+			md.use(mditAnchor,{
+				level: 1,
+				permalink: false
+			})
 
 			tl.debug("Rendering markdown to html...");
 			var result = md.render(data);

--- a/markdown2html/package.json
+++ b/markdown2html/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "markdown-it": "^8.2.2",
     "markdown-it-lazy-headers": "^0.1.3",
+    "markdown-it-anchor": "^4.0.0",
     "vsts-task-lib": "^1.1.0",
     "dustjs-linkedin": "^2.7.5",
     "q": "^1.4.1"


### PR DESCRIPTION
Markdown automatically creates an anchor for each heading (e.g. `## Heading2`) which can be linked to anywhere else in the document (e.g. `[Link to Heading](#heading2)`). Added the markdown-it-anchor plugin to Mardown2Html to support this.

Fixes #2 