### PR TITLE
Enable the markdown-it-imsize plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "markdown-it": "^8.2.2",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-anchor": "^4.0.0",
+    "markdown-it-imsize": "^2.0.1",
     "vsts-task-lib": "^1.1.0",
     "dustjs-linkedin": "^2.7.5",
     "q": "^1.4.1"

--- a/src/Markdown2Html/markdown2html.ts
+++ b/src/Markdown2Html/markdown2html.ts
@@ -26,6 +26,7 @@ import lazyHeaders = require('markdown-it-lazy-headers');
 import dust = require('dustjs-linkedin');
 import util = require('util');
 import mditAnchor = require('markdown-it-anchor');
+import mditImsize = require('markdown-it-imsize')
 
 function transformTemplate(templatePath: string, templateObject: any) {
 	let deferred = q.defer();
@@ -105,6 +106,7 @@ function run() {
 				level: 1,
 				permalink: false
 			})
+			md.use(mditImsize)
 
 			tl.debug("Rendering markdown to html...");
 			var result = md.render(data);


### PR DESCRIPTION
Enables the [markdown-it-imsize plugin](https://www.npmjs.com/package/markdown-it-imsize).

Fixes #6 